### PR TITLE
adding burn feature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.28)
 project(voice.hypha)
 
 include(ExternalProject)

--- a/include/voice.hpp
+++ b/include/voice.hpp
@@ -86,6 +86,20 @@ class [[eosio::contract("voice.hypha")]] voice : public eosio::contract {
                        const asset&   quantity,
                        const string&  memo );
 
+        /**
+          * Allows `to` account to burn `quantity` tokens. The tokens are destroyed and removed
+          * from the stats table and the account. 
+          *
+          * @param from - the account to burn tokens from,
+          * @param quantity - the quantity of tokens to be transferred,
+          * @param memo - the memo string to accompany the transaction.
+          */
+        [[eosio::action]]
+        void burn( const name&    tenant,
+                       const name&    from,
+                       const asset&   quantity,
+                       const string&  memo );
+
 
         // Runs decaying actions
         ACTION decay(const name& tenant, const name& owner, symbol symbol);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.28)
 project(voice-hypha-build)
 set(EOSIO_WASM_OLD_BEHAVIOR "Off")
 find_package(eosio.cdt)

--- a/src/voice.cpp
+++ b/src/voice.cpp
@@ -172,6 +172,28 @@ namespace hypha {
         sub_balance( tenant, from, quantity );
         add_balance( tenant, to, quantity, payer );
     }
+    
+    void voice::burn( const name&    tenant,
+                          const name&    from,
+                          const asset&   quantity,
+                          const string&  memo )
+    {
+        require_auth( from );
+        auto sym = quantity.symbol.code();
+        stats statstable( get_self(), sym.raw() );
+        auto index = statstable.get_index<name("bykey")>();
+        const auto& st = index.get( currency_statsv2::build_key(tenant, sym) );
+
+        require_recipient( from );
+
+        check( quantity.is_valid(), "invalid quantity" );
+        check( quantity.amount > 0, "must burn positive quantity" );
+        check( quantity.symbol == st.supply.symbol, "symbol precision mismatch" );
+        check( memo.size() <= 256, "memo has more than 256 bytes" );
+
+        sub_balance( tenant, from, quantity );
+    }
+
 
     void voice::decay(const name& tenant, const name& owner, symbol symbol) {
         stats statstable( get_self(), symbol.code().raw() );
@@ -209,7 +231,6 @@ namespace hypha {
     }
 
     void voice::sub_balance(const name& tenant, const name& owner, const asset& value ) {
-        this->decay(tenant, owner, value.symbol);
         accounts from_acnts( get_self(), owner.value );
         auto index = from_acnts.get_index<name("bykey")>();
 

--- a/src/voice.cpp
+++ b/src/voice.cpp
@@ -192,6 +192,8 @@ namespace hypha {
         check( memo.size() <= 256, "memo has more than 256 bytes" );
 
         sub_balance( tenant, from, quantity );
+        
+        update_issued(tenant, -1 * quantity);
     }
 
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.28)
 project(voice.hypha.tests)
 find_package(eosio.cdt)
 


### PR DESCRIPTION
note: I removed decay from sub_balance - that was a bug. add_balance also shouldn't have decay built in... it's a weird side effect

I can't get these unit tests to work so created a bunch of unit tests in @hypha-dao/hypha-smart-contracts 

https://github.com/hypha-dao/hypha-smart-contracts

The new tests are here:

https://github.com/hypha-dao/hypha-smart-contracts/blob/main/test_old/voice_token.test.js